### PR TITLE
Add Normalized Mutual Information and Element Centric Similarity as alternatives to modularity

### DIFF
--- a/emlens/metrics.py
+++ b/emlens/metrics.py
@@ -135,7 +135,7 @@ def nmi(emb, group_ids, A=None, k=10):
     :type A: scipy.csr_matrix, optional
     :param k: Number of the nearest neighbors, defaults to 10
     :type k: int, optional
-    :return: modularity
+    :return: normalized mutual information
     :rtype: float
 
     .. highlight:: python
@@ -178,15 +178,19 @@ def element_sim(emb, group_ids, A=None, k=10, alpha=0.9):
     """Calculate the Element Centric Clustering Similarity for the entities
     with group membership.
 
-    Gates, A. J., Wood, I. B., Hetrick, W. P., & Ahn, Y. Y. (2019). Element-centric clustering comparison unifies overlaps and hierarchy. Scientific Reports, 9(1), 1–13. https://doi.org/10.1038/s41598-019-44892-y
+    Gates, A. J., Wood, I. B., Hetrick, W. P., & Ahn, Y. Y. (2019).
+    Element-centric clustering comparison unifies overlaps and hierarchy.
+    Scientific Reports, 9(1), 1–13. https://doi.org/10.1038/s41598-019-44892-y
 
-    This similarity takes a value between [0,1]. A larger value indicates that nodes with the same group membership tend to be close each other. Zero value means that
-    membership `group_ids` is independent of the embedding.
+    This similarity takes a value between [0,1]. A larger value indicates that nodes with the same group
+    membership tend to be close each other. Zero value means that membership `group_ids` is independent of
+    the embedding.
 
     The Element Centric Clustering Similarity is calculated as follows.
     1. Construct a k-nearest neighbor graph.
     2. For each edge connecting nodes i and j (i<j), find the groups g_i and g_j to which the nodes belong.
-    4. Make a list, L, of g_i's for nodes at the one end of the edges. Then, make another list, L', of nodes at the other end of the edges.
+    4. Make a list, L, of g_i's for nodes at the one end of the edges. Then, make another list, L', of nodes
+       at the other end of the edges.
     5. Calculate the difference between L and L' using the Element Centric Clustering Similarity.
 
     :param emb: embedding vectors
@@ -199,7 +203,7 @@ def element_sim(emb, group_ids, A=None, k=10, alpha=0.9):
     :type k: int, optional
     :param alpha: one minus restarting probability, defaults to 0.9
     :type alpha: float, optional
-    :return: modularity
+    :return: element centric similarity
     :rtype: float
 
     .. highlight:: python

--- a/emlens/metrics.py
+++ b/emlens/metrics.py
@@ -145,7 +145,7 @@ def nmi(emb, group_ids, A=None, k=10):
         >>> import numpy as np
         >>> emb = np.random.randn(100, 20)
         >>> g = np.random.choice(10, 100)
-        >>> rho = emlens.modularity(emb, g)
+        >>> rho = emlens.nmi(emb, g)
     """
     if A is None:
         A = make_knn_graph(emb, k=k)

--- a/emlens/metrics.py
+++ b/emlens/metrics.py
@@ -239,7 +239,7 @@ def element_sim(emb, group_ids, A=None, k=10):
     # In ddition, denote by n_{rc} the number of elements that belong to group r in partition A and group c in partition B.
     # By substituting p_ij = alpha / n_A + (1-alpha) * (i == j), we have
     #   S_i = 0.5 * n_{rc} * ( 1/n^A _{g^A _i} +  1/n^B _{g^B _i} - |1/n^A _{g^A _i} - 1/n^B _{g^B _i}|).
-    # Computing this for N nodes requires memory and computation time in order O(NK), where K is the number of groups.
+    # Computing this for N nodes requires memory and computation time in order of O(NK), where K is the number of groups.
     # This order can be substantially lower than O(N^2) if K<<N.
     UA = sparse.csr_matrix((np.ones_like(gA), (np.arange(gA.size), gA)), shape=(M, K))
     UB = sparse.csr_matrix((np.ones_like(gB), (np.arange(gB.size), gB)), shape=(M, K))

--- a/emlens/metrics.py
+++ b/emlens/metrics.py
@@ -236,7 +236,7 @@ def element_sim(emb, group_ids, A=None, k=10):
     #   = 2 - \sum_{g^A _i = g^A _j and g^B _i = g^B _j} |p^A _{ij}| + |p^B _{ij}| -  |p^A _{ij} - p^B _{ij}|.
     # where g^A _i is the membership of i in partition A.
     # Denote by n^A _r the number of elements that belong to group r in partition A (and we analagously define n^B _c).
-    # In ddition, Denote by n_{rc} the number of elements that belong to group r in partition A and group c in partition B.
+    # In ddition, denote by n_{rc} the number of elements that belong to group r in partition A and group c in partition B.
     # By substituting p_ij = alpha / n_A + (1-alpha) * (i == j), we have
     #   S_i = 0.5 * n_{rc} * ( 1/n^A _{g^A _i} +  1/n^B _{g^B _i} - |1/n^A _{g^A _i} - 1/n^B _{g^B _i}|).
     # Computing this for N nodes requires memory and computation time in order O(NK), where K is the number of groups.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 faiss
-numpy
+numpy>=1.16.5
 scikit-learn
 scipy

--- a/tests/simple_test.py
+++ b/tests/simple_test.py
@@ -9,8 +9,7 @@ import emlens
 
 class TestCalc(unittest.TestCase):
     def setUp(self):
-        emb_url = "https://raw.githubusercontent.com/skojaku/emlens/main/data/airportnet/emb.txt"
-        self.emb = np.loadtxt(emb_url)
+        self.emb = np.random.randn(300, 30)
         self.deg = np.random.randn(self.emb.shape[0])
         self.membership = np.random.randint(10, size=self.emb.shape[0])
         self.K = len(set(self.membership))

--- a/tests/simple_test.py
+++ b/tests/simple_test.py
@@ -37,6 +37,9 @@ class TestCalc(unittest.TestCase):
     def test_modularity(self):
         emlens.modularity(self.emb, self.membership)
 
+    def test_nmi(self):
+        emlens.nmi(self.emb, self.membership)
+
     def test_pairwise_dot_similarity(self):
         S, _ = emlens.pairwise_dot_sim(self.emb, self.membership)
         self.assertEqual(S.shape[1], self.K)

--- a/tests/simple_test.py
+++ b/tests/simple_test.py
@@ -40,6 +40,9 @@ class TestCalc(unittest.TestCase):
     def test_nmi(self):
         emlens.nmi(self.emb, self.membership)
 
+    def test_element_sim(self):
+        emlens.element_sim(self.emb, self.membership)
+
     def test_pairwise_dot_similarity(self):
         S, _ = emlens.pairwise_dot_sim(self.emb, self.membership)
         self.assertEqual(S.shape[1], self.K)


### PR DESCRIPTION
 In this update, I added the Normalized Mutual Information to quantify how well nodes are clustered into some prescribed groups in an embedding space.

`emlens` already has `modularity` that provides a quantity in the same vein. But the modularity would depend on the number of edges in the k-nn graph and have a preference in cluster sizes due to the resolution limit.
 
NMI is an alternative to modularity, independent of the number of edges, and would have a weaker preference in cluster size.

NMI is calculated as follows. 
1.  I construct a k-nearest neighbor graph. 
2. For each edge connecting nodes i and j, find the groups g_i and g_j to which nodes i and j belong. 
3. Compute the joint distribution of g_i and g_j, denoted by P(g_i, g_j)
4. With P(g_i, g_j), compute the Normalized Mutual Information