### PR TITLE
Fix bug that occurs when using numpy array created by cython code

### DIFF
--- a/emlens/metrics.py
+++ b/emlens/metrics.py
@@ -26,6 +26,9 @@ def make_knn_graph(emb, k=5, binarize=True):
         >>> emb = np.random.randn(100, 20)
         >>> A = emlens.make_knn_graph(emb, k = 10)
     """
+    if emb.flags["C_CONTIGUOUS"]:
+        emb = emb.copy(order="C")
+
     # Find the nearest neighbors
     index = faiss.IndexFlatL2(emb.shape[1])
     index.add(emb.astype(np.float32))


### PR DESCRIPTION
This pull request is to fix a bug that arises when the input array is created by cython code. 